### PR TITLE
scipy: fix ambiguous version warnings

### DIFF
--- a/scipy/pixi.toml
+++ b/scipy/pixi.toml
@@ -175,15 +175,15 @@ platforms = ["linux-64", "osx-arm64"]
 [feature.jax-cpu.dependencies]
 # 0.5.1-2 are broken, wait for 0.5.3 (conda-forge/jaxlib-feedstock#308)
 # see rgommers/pixi-dev-scipystack/pull/14 for more details
-jax = "0.5.0"
-jaxlib = { version = "0.5.0", build = "*cpu*" }
+jax = "==0.5.0"
+jaxlib = { version = "==0.5.0", build = "*cpu*" }
 
 [feature.jax-cuda]
 platforms = ["linux-64"]
 
 [feature.jax-cuda.dependencies]
-jax = "0.5.0"
-jaxlib = { version = "0.5.0", build = "*cuda*" }
+jax = "==0.5.0"
+jaxlib = { version = "==0.5.0", build = "*cuda*" }
 
 [feature.jax-base.tasks]
 test-jax = { cmd = "spin test -b jax.numpy", cwd = "scipy" }


### PR DESCRIPTION
```
 WARN Encountered ambiguous version specifier `0.5.0`, could be `0.5.0.*` but assuming you meant `==0.5.0`. In the future this will result in an error.
 WARN Encountered ambiguous version specifier `0.5.0`, could be `0.5.0.*` but assuming you meant `==0.5.0`. In the future this will result in an error.
 WARN Encountered ambiguous version specifier `0.5.0`, could be `0.5.0.*` but assuming you meant `==0.5.0`. In the future this will result in an error.
 WARN Encountered ambiguous version specifier `0.5.0`, could be `0.5.0.*` but assuming you meant `==0.5.0`. In the future this will result in an error.
```