### PR TITLE
scipy: discard meson cache

### DIFF
--- a/scipy/pixi.toml
+++ b/scipy/pixi.toml
@@ -68,7 +68,7 @@ linkify-it-py = "*"
 ipython = { cmd = "spin ipython", cwd = "scipy" }
 
 [feature.build.tasks]
-build = { cmd = "spin build -C-Dblas=blas -C-Dlapack=lapack -C-Duse-g77-abi=true", cwd = "scipy", env = { CC = "ccache $CC", CXX = "ccache $CXX", FC = "ccache $FC" } }
+build = { cmd = "spin build -C-Dblas=blas -C-Dlapack=lapack -C-Duse-g77-abi=true -C--clearcache", cwd = "scipy", env = { CC = "ccache $CC", CXX = "ccache $CXX", FC = "ccache $FC" } }
 wheel = { cmd = "python -m build -wnx -Cbuild-dir=build-whl && cp dist/*.whl ../../wheelhouse/", cwd = "scipy" }
 profile-build = { cmd = "rm -rf build-profile && meson setup build-profile && ninja -C build-profile && python tools/ninjatracing.py build-profile/.ninja_log > build-profile/trace.json", cwd = "scipy" }
 check-missingdeps = { cmd = "ninja -C build -t missingdeps", depends-on = [
@@ -116,7 +116,7 @@ platforms = ["osx-arm64"]
 libblas = { version = "*", build = "*accelerate" }
 
 [feature.accelerate.tasks]
-build-accelerate = { cmd = "spin build --build-dir=build-accelerate --with-accelerate", cwd = "scipy", env = { CC = "ccache $CC", CXX = "ccache $CXX", FC = "ccache $FC" } }
+build-accelerate = { cmd = "spin build --build-dir=build-accelerate  -C--clearcache --with-accelerate", cwd = "scipy", env = { CC = "ccache $CC", CXX = "ccache $CXX", FC = "ccache $FC" } }
 test-accelerate = { cmd = "spin test --build-dir=build-accelerate", cwd = "scipy", depends-on = "build-accelerate" }
 
 [feature.netlib.dependencies]
@@ -241,7 +241,7 @@ pytest-run-parallel = ">=0.4.3"
 pythran = ">=0.18.0"  # FIXME conda 0.18.0 build not available yet
 
 [feature.free-threading.tasks]
-build-nogil = { cmd = "spin build --build-dir=build-nogil -C-Dblas=blas -C-Dlapack=lapack -C-Duse-g77-abi=true", cwd = "scipy", env = { CC = "ccache $CC", CXX = "ccache $CXX", FC = "ccache $FC" } }
+build-nogil = { cmd = "spin build --build-dir=build-nogil -C-Dblas=blas -C-Dlapack=lapack -C-Duse-g77-abi=true -C--clearcache", cwd = "scipy", env = { CC = "ccache $CC", CXX = "ccache $CXX", FC = "ccache $FC" } }
 test-nogil = { cmd = "spin test --build-dir=build-nogil", cwd = "scipy" }
 
 
@@ -273,14 +273,14 @@ numpy = ">=2.2.0.rc0" # hack, force install from PyPI
 pythran = ">=0.17.0"
 
 [feature.openblas-src.tasks]
-build-openblas-src = { cmd = "spin build --build-dir build-openblas -C-Dblas=openblas-src -C-Dbuildtype=release", cwd = "scipy", env = { CC = "ccache $CC", CXX = "ccache $CXX", FC = "ccache $FC" } }
-test-openblas-src = { cmd = "spin test --build-dir build-openblas", cwd = "scipy" }
-wheel-openblas-src = { cmd = "python -m build -wnx -Cbuild-dir=build-whl-openblas -Csetup-args=-Dblas=openblas-src", cwd = "scipy", env = { CC = "ccache $CC", CXX = "ccache $CXX", FC = "ccache $FC" } }
+build-openblas-src = { cmd = "spin build --build-dir=build-openblas -C-Dblas=openblas-src -C-Dbuildtype=release", cwd = "scipy", env = { CC = "ccache $CC", CXX = "ccache $CXX", FC = "ccache $FC" } }
+test-openblas-src = { cmd = "spin test --build-dir=build-openblas", cwd = "scipy" }
+wheel-openblas-src = { cmd = "python -m build -wnx -Cbuild-dir=build-whl-openblas -Csetup-args=-Dblas=openblas-src -C--clearcache", cwd = "scipy", env = { CC = "ccache $CC", CXX = "ccache $CXX", FC = "ccache $FC" } }
 test-openblas-src-wheel = { cmd = "pip install ../dist/scipy*.whl --force-reinstall && python -c 'import scipy as s; s.test()'", cwd = "scipy/tools" }
 
 
 [feature.editable.tasks]
-build-editable = { cmd = "spin install -- -Cbuild-dir=build-editable -Csetup-args=-Dblas=blas -Csetup-args=-Dlapack=lapack -Csetup-args=-Duse-g77-abi=true", cwd = "scipy", env = { CC = "ccache $CC", CXX = "ccache $CXX", FC = "ccache $FC" } }
+build-editable = { cmd = "spin install -- -Cbuild-dir=build-editable -Csetup-args=-Dblas=blas -Csetup-args=-Dlapack=lapack -Csetup-args=-Duse-g77-abi=true -C--clearcache", cwd = "scipy", env = { CC = "ccache $CC", CXX = "ccache $CXX", FC = "ccache $FC" } }
 test-editable = { cmd = "spin test --build-dir=build-editable", cwd = "scipy" }
 doc-editable = { cmd = "spin docs --build-dir=build-editable -j6", cwd = "scipy" }
 smoke-docs = { cmd = "spin smoke-docs --build-dir=build-editable", cwd = "scipy" }


### PR DESCRIPTION
Fix bug where fortran modules would build against a version of numpy that is not the one installed in the pixi  environment; e.g. the env contains numpy==2.4.0.dev0 but meson uses headers and links against numpy 2.2.