### PR TITLE
scipy: `activation.env` for `SCIPY_ARRAY_API`

### DIFF
--- a/scipy/pixi.toml
+++ b/scipy/pixi.toml
@@ -446,7 +446,7 @@ torch-cuda = ["array_api", "cuda", "torch-cuda", "mkl"]
 cupy = ["array_api", "cupy"]
 jax = ["array_api", "jax-cpu"]
 jax-cuda = ["array_api", "cuda", "jax-cuda"]
-mlx = ["array_api","mlx"]
+mlx = ["array_api", "mlx"]
 array-api-strict = ["array_api", "array_api_strict"]
 array-api = [
   "array_api",


### PR DESCRIPTION
I think this addresses a TODO you added @rgommers !

```console
pixi-dev-scipystack/scipy on 🎋 activation [🔨] via 🧚 v0.54.1
❯ pixi shell -e torch

pixi-dev-scipystack/scipy on 🎋 activation [🔨] via 🧚 v0.54.1 (torch)
❯ $env.SCIPY_ARRAY_API
1
```